### PR TITLE
add support for loading ini files

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,20 @@
+
+instance = default
+
+[worker-b]
+enabled = true
+interval = 5s
+
+[worker-a]
+enabled = true
+data = "foo bar baz"
+interval = 5s
+
+[processor-foo]
+enabled = true
+
+[processor-bar]
+enabled = false
+
+[api]
+listen = ":8083"

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 ---
+instance: default
 worker-b:
   enabled: true
   interval: 5s


### PR DESCRIPTION
viper does not support ini files. So we load the ini file, then
write it to a bytes.Buffer as a yaml file, then load it into viper.